### PR TITLE
Add Account.TOTP field, parse positional index 39, send `totp` on upsert

### DIFF
--- a/account.go
+++ b/account.go
@@ -34,6 +34,12 @@ type Account struct {
 	// Timestamp in seconds (set by LastPass servers).
 	LastModifiedGMT string
 	LastTouch       string
+	// TOTP is the One-time passcode shared secret (base32 without
+	// padding, as accepted by RFC 6238 authenticator apps). When
+	// non-empty, LastPass renders the live TOTP code next to the
+	// entry in the web vault. Older ACCT records on the wire do not
+	// carry this field and round-trip as an empty string.
+	TOTP string
 }
 
 type encryptedAccount struct {
@@ -47,6 +53,7 @@ type encryptedAccount struct {
 	notes           []byte
 	lastModifiedGMT string
 	lastTouch       string
+	totp            []byte
 }
 
 // share represents a LastPass shared folder.
@@ -234,6 +241,28 @@ func parseAccount(r io.Reader) (*encryptedAccount, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Positions 32-38 are LP-internal fields we don't care about.
+	// Position 39 carries the encrypted TOTP shared secret (added by
+	// LastPass after this library's original field map was written).
+	// Older ACCT records on the wire stop short of position 39, so
+	// EOF mid-tail is treated as "no TOTP" rather than a parse error.
+	var totpEncrypted []byte
+	for i := 0; i < 7; i++ {
+		if err = skipItem(r); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				err = nil
+				break
+			}
+			return nil, err
+		}
+	}
+	if err == nil {
+		if totpItem, terr := readItem(r); terr == nil {
+			totpEncrypted = totpItem
+		} else if !errors.Is(terr, io.EOF) && !errors.Is(terr, io.ErrUnexpectedEOF) {
+			return nil, terr
+		}
+	}
 	return &encryptedAccount{
 		string(id),
 		nameEncrypted,
@@ -244,6 +273,7 @@ func parseAccount(r io.Reader) (*encryptedAccount, error) {
 		notesEncrypted,
 		string(lastModifiedGMT),
 		string(lastTouch),
+		totpEncrypted,
 	}, nil
 }
 
@@ -288,6 +318,13 @@ func decryptAccount(encrypted *encryptedAccount, encryptionKey []byte) (*Account
 	if err != nil {
 		return nil, err
 	}
+	// TOTP is optional. Empty for records that pre-date the LP TOTP
+	// rollout and for entries where the user never set a one-time
+	// passcode; decryptItem already returns "" for empty input.
+	totp, err := decryptItem(encrypted.totp, encryptionKey)
+	if err != nil {
+		return nil, err
+	}
 	return &Account{
 		encrypted.id,
 		name,
@@ -299,6 +336,7 @@ func decryptAccount(encrypted *encryptedAccount, encryptionKey []byte) (*Account
 		notes,
 		encrypted.lastModifiedGMT,
 		encrypted.lastTouch,
+		totp,
 	}, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -367,6 +367,15 @@ func (c *Client) upsert(ctx context.Context, acct *Account) (result, error) {
 		return response.Result, err
 	}
 
+	// LastPass renders the live TOTP code from this field when set.
+	// encryptAESCBC returns "" for an empty plaintext, which mirrors
+	// the empty `totp=` parameter LP itself sends from the web vault
+	// for entries without a one-time passcode.
+	totpEncrypted, err := encryptAESCBC(acct.TOTP, key)
+	if err != nil {
+		return response.Result, err
+	}
+
 	data := url.Values{
 		"extjs":     []string{"1"},
 		"token":     []string{c.session.Token},
@@ -379,6 +388,7 @@ func (c *Client) upsert(ctx context.Context, acct *Account) (result, error) {
 		"username":  []string{userNameEncrypted},
 		"password":  []string{passwordEncrypted},
 		"extra":     []string{notesEncrypted},
+		"totp":      []string{totpEncrypted},
 	}
 	if share.id != "" {
 		data.Set("sharedfolderid", share.id)


### PR DESCRIPTION
## Summary

LastPass stores the per-account "One-time passcode" shared secret as a dedicated positional field at index 39 of the encrypted `ACCT` chunk. This library previously parsed only through position 31 (`lastModifiedGMT`) and skipped writing the corresponding `totp` form parameter on upsert, so entries written by this library never populated the LP UI's "One-time passcode" slot.

## Changes

- `account.go`: add `Account.TOTP` and `encryptedAccount.totp`.
- `account.go::parseAccount`: after `lastModifiedGMT`, skip positions 32-38 and read position 39. EOF-tolerant — old/short ACCT records on the wire pre-date the TOTP rollout and round-trip as empty TOTP rather than a parse error.
- `account.go::decryptAccount`: decrypt the new field with the vault (or share) key, reusing the existing `decryptItem` path.
- `client.go::upsert`: encrypt via `encryptAESCBC` (same `!iv|ct` AES-256-CBC format LP uses for every other encrypted positional field) and send as the `totp` form parameter on `/show_website.php`. Matches the form shape captured from a live LP web vault save.

## Verification

Value format verified against a real LP DevTools capture from the LP web vault:

- Parameter name on the wire: `totp`
- Value format: `!<base64-iv>|<base64-ciphertext>` (matches every other encrypted field)
- Encryption key: the user vault key (or shared-folder key for shared accounts) — same path as `Username`/`Password`

Two captures inspected: (1) a save without a TOTP value showed `totp=` in the body (confirming the field is part of every save), (2) a save with `JBSWY3DPEHPK3PXP` showed the expected `!iv|ct` shape with 16-byte IV and 32-byte ciphertext (one full PKCS7 padding block for a 16-byte plaintext).

## Test impact

No new regressions. The four pre-existing failures in `TestLastpassGo`'s upsert specs reproduce on the clean tree before this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)