### PR TITLE
Add Client.ShareAccessible (missed PR #3 merge window)

### DIFF
--- a/account.go
+++ b/account.go
@@ -498,3 +498,22 @@ func (c *Client) getShare(ctx context.Context, shareName string) (share, error) 
 func (a *Account) isShared() bool {
 	return strings.HasPrefix(a.Share, "Shared-")
 }
+
+// ShareAccessible reports whether the shared folder shareName is visible
+// to the logged-in account (exists), and whether it is writable for this
+// user (not marked read-only). exists is false with a nil error when the
+// folder simply isn't shared with this account — callers use this to
+// fail fast before writing an entry that would have nowhere to go.
+func (c *Client) ShareAccessible(ctx context.Context, shareName string) (exists bool, writable bool, err error) {
+	s, err := c.getShare(ctx, shareName)
+	if err != nil {
+		// getShare returns a "shared folder %s not found" error when the
+		// folder isn't shared with this account; treat that as a clean
+		// "does not exist" rather than a hard failure.
+		if strings.Contains(err.Error(), "not found") {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	return true, !s.readOnly, nil
+}


### PR DESCRIPTION
## Why a separate PR

This is the `ShareAccessible` commit that was pushed to the `never-autofill-field` branch ~3 minutes **after** PR #3 had already been merged, so it never landed on `master`. PR #3's merge commit (`eb9f738`) contains only `Account.DisableAutofill`.

veloce-authentificator `main` is currently pinned to the dangling branch commit `1dfd071` (which has this change) — it builds today but is fragile (breaks if the merged branch is deleted/GC'd). This PR puts `ShareAccessible` on `master` so authentificator can re-pin to a real master commit.

## Change

Cherry-pick of `1dfd071`: adds `Client.ShareAccessible(ctx, name) (exists, writable bool, err error)` — a thin wrapper over the existing `getShare`, returning `exists=false` (nil err) when the folder simply isn't shared with this account. Used by DEVOPS-1120's folder pre-check (housekeeper → authentificator `/share-available`) to fail fast before provisioning a scratch user whose `Shared-SF-<user>` folder doesn't exist.

No behavior change to existing code; purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)